### PR TITLE
[PLA-7458] bumped log4j version from 2.14.1 to 2.11.0.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 
 ThisBuild / scalaVersion       := "2.12.10"
 ThisBuild / crossScalaVersions := List("2.12.10", "2.13.5")
-ThisBuild / version            := "0.0.3"
+ThisBuild / version            := "0.0.4"
 ThisBuild / organization       := "io.citrine"
 ThisBuild / organizationName   := "Citrine Informatics"
 ThisBuild / artifactClassifier := Some(System.getProperty("os.name").replace(' ', '_'))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,5 +3,5 @@ import sbt._
 object Dependencies {
   lazy val breeze = "org.scalanlp"             %% "breeze"           % "1.1"
   lazy val jblas  = "org.jblas"                %  "jblas"            % "1.2.5"
-  lazy val log4j  = "org.apache.logging.log4j" %  "log4j-slf4j-impl" % "2.14.1"
+  lazy val log4j  = "org.apache.logging.log4j" %  "log4j-slf4j-impl" % "2.11.0"
 }


### PR DESCRIPTION
We're seeing errors in the logs that log4j is unable to load a configuration file. We think this might be due to incompatible log4j versions, so this PR sets the version to the same version we use elsewhere on the platform.

relevant ticket: https://citrine.atlassian.net/browse/PLA-7458