### PR TITLE
PNE-8934: Fix native memory leak in EcosSolve JNI wrapper

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies._
 
 ThisBuild / scalaVersion       := "2.13.15"
-ThisBuild / version            := "0.0.12"
+ThisBuild / version            := "0.0.14"
 ThisBuild / versionScheme      := Some("early-semver")
 ThisBuild / organization       := "io.citrine"
 ThisBuild / organizationName   := "Citrine Informatics"

--- a/src/native/NativeECOS.c
+++ b/src/native/NativeECOS.c
@@ -116,6 +116,18 @@ JNIEXPORT jint JNICALL Java_io_citrine_ecos_NativeECOS_EcosSolve(JNIEnv *env, jo
 		ECOS_cleanup(wspace, 0);
 	}
 
+	/* JNI_ABORT: inputs are read-only, discard any copy without writing back. */
+	(*env)->ReleaseIntArrayElements(env, q, qPtr, JNI_ABORT);
+	(*env)->ReleaseDoubleArrayElements(env, Gpr, GprPtr, JNI_ABORT);
+	(*env)->ReleaseIntArrayElements(env, Gjc, GjcPtr, JNI_ABORT);
+	(*env)->ReleaseIntArrayElements(env, Gir, GirPtr, JNI_ABORT);
+	(*env)->ReleaseDoubleArrayElements(env, Apr, AprPtr, JNI_ABORT);
+	(*env)->ReleaseIntArrayElements(env, Ajc, AjcPtr, JNI_ABORT);
+	(*env)->ReleaseIntArrayElements(env, Air, AirPtr, JNI_ABORT);
+	(*env)->ReleaseDoubleArrayElements(env, c, cPtr, JNI_ABORT);
+	(*env)->ReleaseDoubleArrayElements(env, h, hPtr, JNI_ABORT);
+	(*env)->ReleaseDoubleArrayElements(env, b, bPtr, JNI_ABORT);
+
 	return exitflag;
 }
 


### PR DESCRIPTION
`Java_io_citrine_ecos_NativeECOS_EcosSolve` pinned 11 JVM arrays via `Get*ArrayElements` but only released 1 (the output). The 10 input pins were leaked on every solve, in my tests around ~5.75 KB of native RSS per call, JVM heap was flat. 

See https://citrineinformatics.slack.com/archives/C06MVKFPYPR/p1785346491886009 for more context.

I confirmed with a local test in Mithril as per @mVenetos97 [idea](https://citrineinformatics.slack.com/archives/C06MVKFPYPR/p1785347327613359?thread_ts=1785346491.886009&cid=C06MVKFPYPR): long story short, we had linear RSS growth on the old version, and now  near-flat after this fix. Uses JNI_ABORT since the inputs are read-only, which cheaper than mode 0 and semantically identical here. Releases sit on both the success and failure paths.

Bumps to 0.0.14.